### PR TITLE
Handle closed type families with instances

### DIFF
--- a/scrod.cabal
+++ b/scrod.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.2
 name: scrod
-version: 0.2024.11.1
+version: 0.2024.12.10
 category: Documentation
 description: Scrod is like Haddock but worse.
 extra-doc-files:

--- a/source/library/Scrod.hs
+++ b/source/library/Scrod.hs
@@ -69,7 +69,7 @@ testSuite = Hspec.hspec . Hspec.parallel . Hspec.describe "Scrod" $ do
           let lHsModule = either (error . show) id $ parseLHsModule "<interactive>" string
               items = lHsModuleToItems lHsModule
               lHsDocStrings = getLHsDocStrings lHsModule
-           in mergeItems $ associateDocStrings items lHsDocStrings
+           in associateDocStrings items lHsDocStrings
 
         p l c = Position.Position {Position.line = l, Position.column = c}
 
@@ -460,13 +460,6 @@ testSuite = Hspec.hspec . Hspec.parallel . Hspec.describe "Scrod" $ do
     Hspec.it "discovers a language edition" $ do
       discoverExtensions "{-# language GHC2021 #-}" `Hspec.shouldBe` (Just Session.GHC2021, [])
 
-mergeItems :: (Monoid a) => [(Item.Item, a)] -> [(Item.Item, a)]
-mergeItems items = case items of
-  [] -> items
-  (i, a) : is ->
-    let (ts, fs) = List.partition ((==) (Item.name i) . Item.name . fst) is
-     in (i, a <> foldMap snd ts) : mergeItems fs
-
 discoverExtensions :: String -> (Maybe Session.Language, [Session.OnOff X.Extension])
 discoverExtensions = Unsafe.unsafePerformIO . discoverExtensionsIO
 
@@ -597,7 +590,7 @@ application request respond = do
                   Right lHsModule -> do
                     let items = lHsModuleToItems lHsModule
                         lHsDocStrings = getLHsDocStrings lHsModule
-                        tuples = mergeItems $ associateDocStrings items lHsDocStrings
+                        tuples = associateDocStrings items lHsDocStrings
                     if null tuples
                       then H.p_ "Nothing to see here."
                       else H.ul_ . Monad.forM_ tuples $ \(item, docStrings) -> H.li_ $ do

--- a/source/library/Scrod.hs
+++ b/source/library/Scrod.hs
@@ -82,7 +82,7 @@ testSuite = Hspec.hspec . Hspec.parallel . Hspec.describe "Scrod" $ do
     Hspec.it "closed type family" $ do
       f "type family A where" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, [])]
 
-    Hspec.it "closed type family" $ do
+    Hspec.it "closed type family with instances" $ do
       f "type family A where B = C" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, []), (Item.Item {Item.name = Name.DataInstance "B", Item.position = p 1 21}, [])]
 
     Hspec.it "data family" $ do
@@ -808,11 +808,7 @@ lHsDeclToItems lHsDecl = case SrcLoc.unLoc lHsDecl of
               Nothing -> []
               Just lTyFamInstEqns ->
                 concatMap
-                  ( famEqnToItems
-                      Name.DataInstance
-                      (const [])
-                      . SrcLoc.unLoc
-                  )
+                  (famEqnToItems Name.DataInstance (const []) . SrcLoc.unLoc)
                   lTyFamInstEqns
     HS.SynDecl {HS.tcdLName = lIdP} -> [lIdPToItem Name.TypeSynonym lIdP]
     HS.DataDecl {HS.tcdLName = lIdP, HS.tcdDataDefn = hsDataDefn} ->

--- a/source/library/Scrod.hs
+++ b/source/library/Scrod.hs
@@ -82,7 +82,8 @@ testSuite = Hspec.hspec . Hspec.parallel . Hspec.describe "Scrod" $ do
     Hspec.it "closed type family" $ do
       f "type family A where" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, [])]
 
-    -- TODO: Add items for closed type families: `type family A where B = C`.
+    Hspec.it "closed type family" $ do
+      f "type family A where B = C" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, []), (Item.Item {Item.name = Name.DataInstance "B", Item.position = p 1 21}, [])]
 
     Hspec.it "data family" $ do
       f "data family B" `Hspec.shouldBe` [(Item.Item {Item.name = Name.DataFamily "B", Item.position = p 1 13}, [])]
@@ -793,14 +794,26 @@ lHsDeclToItems lHsDecl = case SrcLoc.unLoc lHsDecl of
   HS.TyClD _ tyClDecl -> case tyClDecl of
     HS.FamDecl {HS.tcdFam = familyDecl} -> case familyDecl of
       HS.FamilyDecl {HS.fdInfo = familyInfo, HS.fdLName = lIdP} ->
-        [ lIdPToItem
-            ( case familyInfo of
-                HS.DataFamily -> Name.DataFamily
-                HS.OpenTypeFamily -> Name.OpenTypeFamily
-                HS.ClosedTypeFamily _ -> Name.ClosedTypeFamily
-            )
-            lIdP
-        ]
+        lIdPToItem
+          ( case familyInfo of
+              HS.DataFamily -> Name.DataFamily
+              HS.OpenTypeFamily -> Name.OpenTypeFamily
+              HS.ClosedTypeFamily _ -> Name.ClosedTypeFamily
+          )
+          lIdP
+          : case familyInfo of
+            HS.DataFamily -> []
+            HS.OpenTypeFamily -> []
+            HS.ClosedTypeFamily mLTyFamInstEqns -> case mLTyFamInstEqns of
+              Nothing -> []
+              Just lTyFamInstEqns ->
+                concatMap
+                  ( famEqnToItems
+                      Name.DataInstance
+                      (const [])
+                      . SrcLoc.unLoc
+                  )
+                  lTyFamInstEqns
     HS.SynDecl {HS.tcdLName = lIdP} -> [lIdPToItem Name.TypeSynonym lIdP]
     HS.DataDecl {HS.tcdLName = lIdP, HS.tcdDataDefn = hsDataDefn} ->
       let dataDefnCons = HS.dd_cons hsDataDefn

--- a/source/library/Scrod.hs
+++ b/source/library/Scrod.hs
@@ -82,10 +82,8 @@ testSuite = Hspec.hspec . Hspec.parallel . Hspec.describe "Scrod" $ do
     Hspec.it "closed type family" $ do
       f "type family A where" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, [])]
 
-    Hspec.it "closed type family with instances" $ do
-      -- The instances don't have items because they can't have documentation
-      -- attached.
-      f "type family A where B = C" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, [])]
+    Hspec.it "closed type family" $ do
+      f "type family A where B = C" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, []), (Item.Item {Item.name = Name.DataInstance "B", Item.position = p 1 21}, [])]
 
     Hspec.it "data family" $ do
       f "data family B" `Hspec.shouldBe` [(Item.Item {Item.name = Name.DataFamily "B", Item.position = p 1 13}, [])]
@@ -796,16 +794,26 @@ lHsDeclToItems lHsDecl = case SrcLoc.unLoc lHsDecl of
   HS.TyClD _ tyClDecl -> case tyClDecl of
     HS.FamDecl {HS.tcdFam = familyDecl} -> case familyDecl of
       HS.FamilyDecl {HS.fdInfo = familyInfo, HS.fdLName = lIdP} ->
-        -- The 'HS.ClosedTypeFamily' constructor can have additional names
-        -- associated with it, but they can't have any documentation attached.
-        [ lIdPToItem
-            ( case familyInfo of
-                HS.DataFamily -> Name.DataFamily
-                HS.OpenTypeFamily -> Name.OpenTypeFamily
-                HS.ClosedTypeFamily _ -> Name.ClosedTypeFamily
-            )
-            lIdP
-        ]
+        lIdPToItem
+          ( case familyInfo of
+              HS.DataFamily -> Name.DataFamily
+              HS.OpenTypeFamily -> Name.OpenTypeFamily
+              HS.ClosedTypeFamily _ -> Name.ClosedTypeFamily
+          )
+          lIdP
+          : case familyInfo of
+            HS.DataFamily -> []
+            HS.OpenTypeFamily -> []
+            HS.ClosedTypeFamily mLTyFamInstEqns -> case mLTyFamInstEqns of
+              Nothing -> []
+              Just lTyFamInstEqns ->
+                concatMap
+                  ( famEqnToItems
+                      Name.DataInstance
+                      (const [])
+                      . SrcLoc.unLoc
+                  )
+                  lTyFamInstEqns
     HS.SynDecl {HS.tcdLName = lIdP} -> [lIdPToItem Name.TypeSynonym lIdP]
     HS.DataDecl {HS.tcdLName = lIdP, HS.tcdDataDefn = hsDataDefn} ->
       let dataDefnCons = HS.dd_cons hsDataDefn

--- a/source/library/Scrod.hs
+++ b/source/library/Scrod.hs
@@ -82,8 +82,10 @@ testSuite = Hspec.hspec . Hspec.parallel . Hspec.describe "Scrod" $ do
     Hspec.it "closed type family" $ do
       f "type family A where" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, [])]
 
-    Hspec.it "closed type family" $ do
-      f "type family A where B = C" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, []), (Item.Item {Item.name = Name.DataInstance "B", Item.position = p 1 21}, [])]
+    Hspec.it "closed type family with instances" $ do
+      -- The instances don't have items because they can't have documentation
+      -- attached.
+      f "type family A where B = C" `Hspec.shouldBe` [(Item.Item {Item.name = Name.ClosedTypeFamily "A", Item.position = p 1 13}, [])]
 
     Hspec.it "data family" $ do
       f "data family B" `Hspec.shouldBe` [(Item.Item {Item.name = Name.DataFamily "B", Item.position = p 1 13}, [])]
@@ -794,26 +796,16 @@ lHsDeclToItems lHsDecl = case SrcLoc.unLoc lHsDecl of
   HS.TyClD _ tyClDecl -> case tyClDecl of
     HS.FamDecl {HS.tcdFam = familyDecl} -> case familyDecl of
       HS.FamilyDecl {HS.fdInfo = familyInfo, HS.fdLName = lIdP} ->
-        lIdPToItem
-          ( case familyInfo of
-              HS.DataFamily -> Name.DataFamily
-              HS.OpenTypeFamily -> Name.OpenTypeFamily
-              HS.ClosedTypeFamily _ -> Name.ClosedTypeFamily
-          )
-          lIdP
-          : case familyInfo of
-            HS.DataFamily -> []
-            HS.OpenTypeFamily -> []
-            HS.ClosedTypeFamily mLTyFamInstEqns -> case mLTyFamInstEqns of
-              Nothing -> []
-              Just lTyFamInstEqns ->
-                concatMap
-                  ( famEqnToItems
-                      Name.DataInstance
-                      (const [])
-                      . SrcLoc.unLoc
-                  )
-                  lTyFamInstEqns
+        -- The 'HS.ClosedTypeFamily' constructor can have additional names
+        -- associated with it, but they can't have any documentation attached.
+        [ lIdPToItem
+            ( case familyInfo of
+                HS.DataFamily -> Name.DataFamily
+                HS.OpenTypeFamily -> Name.OpenTypeFamily
+                HS.ClosedTypeFamily _ -> Name.ClosedTypeFamily
+            )
+            lIdP
+        ]
     HS.SynDecl {HS.tcdLName = lIdP} -> [lIdPToItem Name.TypeSynonym lIdP]
     HS.DataDecl {HS.tcdLName = lIdP, HS.tcdDataDefn = hsDataDefn} ->
       let dataDefnCons = HS.dd_cons hsDataDefn


### PR DESCRIPTION
Note that the instances can't have documentation attached to them. I'm not sure how I should handle things like this in general. But I think it makes sense to generate items for the instances, since I would do that for standalone instances. 